### PR TITLE
Fix publish workflow checkout depth

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -34,6 +36,14 @@ jobs:
         run: |
           pip install pytest
           pytest -q
+
+      - name: Create release tag if missing
+        if: github.ref == 'refs/heads/main'
+        run: |
+          VERSION=$(python setup.py --version)
+          if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            git tag "v$VERSION"
+          fi
 
       - name: Bump version & create tag (semantic-release)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- ensure python publish workflow fetches full history
- create release tag if missing before running semantic-release

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_688aa80e78b8832cbba427d65d478927